### PR TITLE
Add option for subsetting metacommunity

### DIFF
--- a/src/diversity/__main__.py
+++ b/src/diversity/__main__.py
@@ -47,6 +47,7 @@ def main(args):
     meta = make_metacommunity(
         species_counts,
         similarity_matrix=args.similarity_matrix_filepath,
+        subcommunities=args.subcommunities,
         chunk_size=args.chunk_size,
         subcommunity_column=args.subcommunity_column,
         species_column=args.species_column,

--- a/src/diversity/parameters.py
+++ b/src/diversity/parameters.py
@@ -47,6 +47,21 @@ def configure_arguments():
     """
     parser = ArgumentParser()
     parser.add_argument(
+        "-b",
+        "--subcommunities",
+        help=(
+            "Names of subcommunities to include. Effectively makes"
+            " diversity ignore all rows and columns in input file and"
+            " similarity matrix file corresponing to subcommunities"
+            " not in this list and to species not found in any of"
+            " theses subcommunities. The subcommunity names must"
+            " correspond to names in the subcommunity column in input"
+            " file. If unspecified, all subcommunities are included."
+        ),
+        nargs="*",
+        default=None,
+    )
+    parser.add_argument(
         "-c",
         "--count_column",
         help="Header of the column containing the counts.",
@@ -73,7 +88,7 @@ def configure_arguments():
             " WARNING, ERROR, CRITICAL (listed in decreasing"
             " verbosity)."
         ),
-        default="INFO",
+        default="WARNING",
     )
     parser.add_argument(
         "-o",

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -19,6 +19,7 @@ MAIN_TEST_CASES = [
             species_column="species",
             count_column="count",
             chunk_size=1,
+            subcommunities=None,
         ),
         "input_filecontents": (
             "subcommunity\tspecies\tcount\n"
@@ -57,6 +58,7 @@ MAIN_TEST_CASES = [
             species_column="species",
             count_column="count",
             chunk_size=1,
+            subcommunities=None,
         ),
         "input_filecontents": (
             "species\tsubcommunity\tcount\n"
@@ -99,6 +101,7 @@ MAIN_TEST_CASES = [
             species_column="species_",
             count_column="count_",
             chunk_size=1,
+            subcommunities=None,
         ),
         "input_filecontents": (
             "species\tsubcommunity_\tcount_\tspecies_\tsubcommunity\tcount\n"
@@ -141,6 +144,7 @@ MAIN_TEST_CASES = [
             species_column="species",
             count_column="count",
             chunk_size=2,
+            subcommunities=None,
         ),
         "input_filecontents": (
             "species\tsubcommunity\tcount\n"
@@ -148,6 +152,51 @@ MAIN_TEST_CASES = [
             "species_2\tsubcommunity_1\t3\n"
             "species_1\tsubcommunity_2\t5\n"
             "species_3\tsubcommunity_2\t1\n"
+        ),
+        "similarities_filecontents": (
+            "species_1\tspecies_2\tspecies_3\n"
+            "1.0\t0.5\t0.1\n"
+            "0.5\t1.0\t0.2\n"
+            "0.1\t0.2\t1.0\n"
+        ),
+        "output_filecontents": (
+            "community\tviewpoint\talpha\trho\tbeta\tgamma\tnormalized_alpha\tnormalized_rho\tnormalized_beta\n"
+            "subcommunity_1\t2.00\t2.8947\t1.9194\t0.5210\t1.4745\t1.3158\t0.8724\t1.1462\n"
+            "subcommunity_2\t2.00\t2.4444\t1.6587\t0.6029\t1.4570\t1.3333\t0.9047\t1.1053\n"
+            "metacommunity\t2.00\t2.6304\t1.7678\t0.5627\t1.4649\t1.3253\t0.8898\t1.1235\n"
+            "subcommunity_1\t101.00\t2.7641\t1.6836\t0.5940\t1.2908\t1.2564\t0.7653\t1.3067\n"  # 2.76408362, 1.68357822, 0.593973, 1.29084362, 1.25640164, 0.76526283, 1.30674059
+            "subcommunity_2\t101.00\t2.1608\t1.5610\t0.6406\t1.2814\t1.1786\t0.8515\t1.1744\n"  # 2.16079876, 1.56104879, 0.64059497, 1.28140391, 1.1786175, 0.85148116, 1.17442411
+            "metacommunity\t101.00\t2.1739\t1.5705\t0.5987\t1.2849\t1.1858\t0.7713\t1.1816\n"  # 2.1739359070171167, 1.5705327595028187, 0.5986709767832536, 1.2848640573127161, 1.185766665953564, 0.7713202342679308, 1.1815641039291136
+            "subcommunity_1\t102.00\t2.7500\t1.6750\t0.5970\t1.2791\t1.2500\t0.7614\t1.3134\n"  # 2.75, 1.675, 0.59701493, 1.27906977, 1.25, 0.76136364, 1.31343284
+            "subcommunity_2\t102.00\t2.1569\t1.5333\t0.6522\t1.2791\t1.1765\t0.8364\t1.1957\n"  # 2.15686275, 1.53333333, 0.65217391, 1.27906977, 1.17647059, 0.83636364, 1.19565217
+            "metacommunity\t102.00\t2.1569\t1.5333\t0.5970\t1.2791\t1.1765\t0.7614\t1.1957\n"  # 2.156862745098039, 1.5333333333333337, 0.5970149253731344, 1.2790697674418605, 1.176470588235294, 0.7613636363636362, 1.1956521739130435
+            "subcommunity_1\tinf\t2.7500\t1.6750\t0.5970\t1.2791\t1.2500\t0.7614\t1.3134\n"  # 2.75, 1.675, 0.59701493, 1.27906977, 1.25, 0.76136364, 1.31343284
+            "subcommunity_2\tinf\t2.1569\t1.5333\t0.6522\t1.2791\t1.1765\t0.8364\t1.1957\n"  # 2.15686275, 1.53333333, 0.65217391, 1.27906977, 1.17647059, 0.83636364, 1.19565217
+            "metacommunity\tinf\t2.1569\t1.5333\t0.5970\t1.2791\t1.1765\t0.7614\t1.1957\n"  # 2.156862745098039, 1.5333333333333337, 0.5970149253731344, 1.2790697674418605, 1.176470588235294, 0.7613636363636362, 1.1956521739130435
+        ),
+    },
+    {
+        "description": "overlapping communities; non-uniform counts; non-uniform inter-community similarities; viewpoint 2.",
+        "args": Namespace(
+            input_filepath="foo_counts.tsv",
+            output_filepath="bar_counts.tsv",
+            similarity_matrix_filepath="baz_similarities.tsv",
+            viewpoint=[2, 101, 102, inf],
+            log_level="WARNING",
+            subcommunity_column="subcommunity",
+            species_column="species",
+            count_column="count",
+            chunk_size=1,
+            subcommunities={"subcommunity_1", "subcommunity_2"},
+        ),
+        "input_filecontents": (
+            "species\tsubcommunity\tcount\n"
+            "species_1\tsubcommunity_1\t2\n"
+            "species_2\tsubcommunity_1\t3\n"
+            "species_1\tsubcommunity_2\t5\n"
+            "species_3\tsubcommunity_2\t1\n"
+            "species_1\tsubcommunity_3\t3\n"
+            "species_2\tsubcommunity_3\t5\n"
         ),
         "similarities_filecontents": (
             "species_1\tspecies_2\tspecies_3\n"


### PR DESCRIPTION
 via specifying subset of subcommunities to CLI and make_metacommunity.

Also:
- Made species_order an abstract property, since any implementation of ISimilarity should be required to have it
- Removed docstrings from implementations of abstract methods/properties because I noticed that they will then take on their base class's doctoring for that method
- Made sure that all SimilarityFromFile and Abundance options can be specified in CLI