### PR TITLE
Sparse similarity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["numpy>=1.24.0", "pandas>=1.5.2", "ray>=2.2.0", "scipy==1.10.0"]
+dependencies = ["numpy>=1.24.0", "pandas>=1.5.2", "ray>=2.2.0", "scipy>=1.10.0"]
 
 [project.optional-dependencies]
 tests = ["pytest>=6.2.5", "pytest-cov>=3.0.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.24.0
 pandas>=1.5.2
 ray>=2.2.0
-scipy==1.10.0
+scipy>=1.10.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ pytest-cov==3.0.0
 tox==4.3.5
 tox-gh-actions==3.0.0
 black==22.3.0
-numpy==1.24.0
-pandas==1.5.2
-ray==2.2.0
-scipy==1.10.0
+numpy>=1.24.0
+pandas>=1.5.2
+ray>=2.2.0
+scipy>=1.10.0

--- a/src/greylock/abundance.py
+++ b/src/greylock/abundance.py
@@ -18,7 +18,7 @@ from typing import Iterable, Union
 
 from numpy import arange, ndarray, concatenate
 from pandas import DataFrame, RangeIndex
-from scipy.sparse import spmatrix, diags, issparse, hstack
+from scipy.sparse import spmatrix, diags, issparse, hstack, csc_array
 
 
 class Abundance:
@@ -171,6 +171,8 @@ class AbundanceFromSparseArray(Abundance):
                 self.normalized_subcommunity_abundance,
             )
         )
+        # Convert to a type that supports slicing:
+        self.unified_abundance_array = csc_array(self.unified_abundance_array)
         self.metacommunity_abundance = self.unified_abundance_array[:, [0]]
         self.subcommunity_abundance = self.unified_abundance_array[
             :, 1 : (1 + self.num_subcommunities)

--- a/src/greylock/abundance.py
+++ b/src/greylock/abundance.py
@@ -46,7 +46,7 @@ class Abundance:
         self.unify_abundance_array()
 
     def unify_abundance_array(self):
-        """ Creates one matrix containing all the abundance matrices:
+        """Creates one matrix containing all the abundance matrices:
         metacommunity, subcommunity, and normalized subcommunity.
         These matrices are still available as views on the unified
         data structure. (Because we are using basic slicing here, only

--- a/src/greylock/components.py
+++ b/src/greylock/components.py
@@ -50,7 +50,7 @@ class SimilaritySensitiveComponents(Components):
     specified measure"""
 
     def __init__(self, abundance: Abundance, similarity: Similarity) -> None:
-        """ Create the weighted similarity vectors by multipying the
+        """Create the weighted similarity vectors by multipying the
         similarity matrix to each of the metacommunity abundance vector,
         the subcommunity abundance vectors, and the normalized
         subcommunity vectors.

--- a/src/greylock/similarity.py
+++ b/src/greylock/similarity.py
@@ -28,7 +28,7 @@ from abc import ABC, abstractmethod
 from typing import Callable, Union
 from numpy import ndarray, empty, concatenate, float64
 from pandas import DataFrame, read_csv
-from scipy.sparse import spmatrix
+from scipy.sparse import spmatrix, issparse
 from ray import remote, get, put
 
 
@@ -227,6 +227,8 @@ def make_similarity(
         return SimilarityFromFile(similarity=similarity, chunk_size=chunk_size)
     elif isinstance(similarity, Callable):
         return SimilarityFromFunction(similarity=similarity, X=X, chunk_size=chunk_size)
+    elif issparse(similarity):
+        return SimilarityFromArray(similarity=similarity)
     else:
         raise NotImplementedError(
             f"Type {type(similarity)} is not supported for argument "

--- a/src/greylock/tests/similarity_test.py
+++ b/src/greylock/tests/similarity_test.py
@@ -1,5 +1,5 @@
 """Tests for diversity.similarity"""
-from numpy import allclose, ndarray, array, dtype, memmap, inf, float32
+from numpy import allclose, ndarray, array, dtype, memmap, inf, float32, zeros
 from pandas import DataFrame
 from ray import get, init, shutdown
 import scipy.sparse
@@ -301,7 +301,7 @@ def test_weighted_similarity_chunk(ray_fix, similarity_function):
     assert allclose(chunk, weighted_similarities_3by2_3)
 
 
-def make_array(spec, array_class=ndarray):
+def make_array(spec, array_class=zeros):
     a = array_class(spec["shape"], dtype=float32)
     for i, value in enumerate(spec["data"]):
         a[spec["row"][i], spec["col"][i]] = value


### PR DESCRIPTION
Now we allow the similarity matrix to be any kind of scipy sparse array or sparse matrix.
All existing classes or sparse array and sparse matrix provided by scipy (as of version 1.12) now tested and proven to give the same results as the equivalent dense matrix. 
Now compatible not just with scipy 1.10, but also scipy 1.11 and scipy  1.12.
