### PR TITLE
94 move ray dependence into an extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ X = np.array([
 def similarity_function(species_i, species_j):
   return 1 / (1 + np.linalg.norm(species_i - species_j))
 
-metacommunity = Metacommunity(counts,
+metacommunity = Metacommunity(np.array([[1, 1], [1, 0], [0, 1]]),
                               similarity=SimilarityFromFunction(similarity_function,
                                                                X=X, chunk_size=10))
 ```

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ def feature_similarity(animal_i, animal_j):
         result *= 0.5
     return result
 
-metacommunity = Metacommunity(counts,
+metacommunity = Metacommunity(np.array([[1, 1], [1, 0], [0, 1]]),
                               similarity=SimilarityFromFunction(feature_similarity, X=X))
 ```
 

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Rather, one may instantiate `SimilarityFromFile`, whose constructor is given the
 
 To illustrate passing a csv file, we re-use the counts_2b_1 and S_2b from above and save the latter as .csv files (note `index=False`, since the csv files should *not* contain row labels):
 ```python
-S_2b.to_csv("S_2b.csv", index=False)
+S_2b_df.to_csv("S_2b.csv", index=False)
 ```
 then we can build a metacommunity as follows
 ```python

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ Use the `SimilarityFromSymmetricFunction` class to get the same results in half 
 ```python
 from greylock.similarity import SimilarityFromSymmetricFunction
 
-metacommunity = Metacommunity(counts,
+metacommunity = Metacommunity(np.array([[1, 1], [1, 0], [0, 1]]),
                               similarity=SimilarityFromSymmetricFunction(feature_similarity, X=X))
 ```
 

--- a/README.md
+++ b/README.md
@@ -364,7 +364,8 @@ simillarity matrix is of complexity $O(n^2)$ (where $n$ is the number of species
 
 Any large similarity matrix that is created in Python as a `numpy.ndarray` benefits from being memory-mapped, as NumPy can then use the data without requiring it all to be in memory. See the NumPy [memmap documentation](https://numpy.org/doc/stable/reference/generated/numpy.memmap.html) for guidance. Because `memmap` is a subclass of `ndarray`, using this type of file storage for the similarity matrix requires no modification to your use of the Metacommunity API. This conversion, and the resulting storage of the data on disk, has the advantage that if you revise the downstream analysis, or perform additional analyses, re-calculation of the similarity matrix may be skipped.
 
-The strategy of calculate-once, use-many-times afforded by storage of the similarity matrix to a file allows you to do the work of calculating the similarity matrix in an entirely separate process. You may choose to calculate the similarity matrix in a more performant language, such as C++, and/or inspect the matrix in Excel. In these cases, it is  convenient to store the similarity matrix in a non-Python-specific format, such as a .csv or .tsv file. The entire csv/tsv file need not be read into memory before invoking the `Metacommunity` constructor; when this constructor is given the path of a cvs or tsv file, it will use the file's contents in a memory-efficient way, reading in chunks as they are used. 
+The strategy of calculate-once, use-many-times afforded by storage of the similarity matrix to a file allows you to do the work of calculating the similarity matrix in an entirely separate process. You may choose to calculate the similarity matrix in a more performant language, such as C++, and/or inspect the matrix in Excel. In these cases, it is  convenient to store the similarity matrix in a non-Python-specific format, such as a .csv or .tsv file. The entire csv/tsv file need not be read into memory before invoking the `Metacommunity` constructor.
+Rather, one may instantiate `SimilarityFromFile`, whose constructor is given the path of a cvs or tsv file. The `SimilarityFromFile` object will use the file's contents in a memory-efficient way, reading in chunks as they are used. 
 
 To illustrate passing a csv file, we re-use the counts_2b_1 and S_2b from above and save the latter as .csv files (note `index=False`, since the csv files should *not* contain row labels):
 ```python
@@ -372,13 +373,19 @@ S_2b.to_csv("S_2b.csv", index=False)
 ```
 then we can build a metacommunity as follows
 ```python
-metacommunity_2b_1 = Metacommunity(counts_2b_1, similarity='S_2b.csv', chunk_size=5)
+from greylock.similarity import SimilarityFromFile
+metacommunity_2b_1 = Metacommunity(counts_2b_1,
+                                   similarity=SimilarityFromFile('S_2b.csv', chunk_size=5))
 ```
-The optional `chunk_size` argument specifies how many rows of the similarity matrix are read from the file at a time.
+The optional `chunk_size` argument to `SimilarityFromFile`'s constructor specifies how many rows of the similarity matrix are read from the file at a time.
 
-Alternatively, to avoid a large footprint on either RAM or disk, the similarity matrix can be constructed and processed in chunks by passing a similarity function to `similarity` and an array or `DataFrame` of features to `X`. Each row of X represents the feature values of a species. For example, given numeric features all of the same type:
+Alternatively, to avoid a large footprint on either RAM or disk, the similarity matrix can be constructed and processed on the fly. 
+A `SimilarityFromFunction` object generates a similarity matrix from a similarity function, and an array or `DataFrame` of features to `X`. Each row of X represents the feature values of a species. 
+For example, given numeric features all of the same type:
 
-```
+```python
+from greylock.similarity import SimilarityFromFunction
+
 X = np.array([
   [1, 2], 
   [3, 4], 
@@ -388,8 +395,13 @@ X = np.array([
 def similarity_function(species_i, species_j):
   return 1 / (1 + np.linalg.norm(species_i - species_j))
 
-metacommunity = Metacommunity(counts, similarity=similarity_function, X=X, symmetric=True)
+metacommunity = Metacommunity(counts,
+                              similarity=SimilarityFromFunction(similarity_function,
+                                                               X=X, chunk_size=10))
 ```
+
+(The optional `chunk_size` parameter specifies how many rows of the similarity matrix to generate at once; larger values should be faster, as long as the chunks are not too large
+compared to available RAM.)
 
 If there are features of various types, and it would be convenient to address features by name, features can be supplied in a DataFrame. (Note that, because of the use of named tuples to represent species in the similarity function, it is helpful if the column names are valid Python identifiers.)
 
@@ -430,18 +442,42 @@ def feature_similarity(animal_i, animal_j):
         result *= 0.5
     return result
 
-metacommunity = Metacommunity(counts, similarity=feature_similarity, X=X, symmetric=True)
+metacommunity = Metacommunity(counts,
+                              similarity=SimilarityFromFunction(feature_similarity, X=X))
 ```
 
-Each `chunk_size` rows of the similarity matrix are processed as a separate job, and `greylock` uses the [Ray framework](https://pypi.org/project/ray/) to parallelize these jobs. Thanks to this parallelization, up to an N-fold speedup is possible (where N is the number of CPUs).
-
-Set the `symmetric` argument to `True` when the following (typical) conditions hold:
+A two-fold speed-up is possible when the following (typical) conditions hold:
 
 * The similarity matrix is symmetric (i.e. similarity[i, j] == similarity[j, i] for all i and j).
 * The similarity of each species with itself is 1.0.
 * The number of subcommunities is much smaller than the number of species.
 
-If `symmetric=True` then the similarity function will only be called for pairs of rows `species[i], species[j]` where i < j, and the similarity of $species_i$ to $species_j$ will be re-used for the similarity of $species_j$ to $species_i$. Thus, a nearly 2-fold speed-up is possible, if the similarity function is computationally expensive. (For a discussion of nonsymmetric similarity, see [Leinster and Cobbold](https://doi.org/10.1890/10-2402.1).)
+In this case, we don't really need to call the simularity function twice for each pair to calcuate both  similarity[i, j] and similarity[j, i]. 
+Use the `SimilarityFromSymmetricFunction` class to get the same results in half the time:
+
+```python
+from greylock.similarity import SimilarityFromSymmetricFunction
+
+metacommunity = Metacommunity(counts,
+                              similarity=SimilarityFromSymmetricFunction(feature_similarity, X=X))
+```
+
+The similarity function will only be called for pairs of rows `species[i], species[j]` where i < j, and the similarity of $species_i$ to $species_j$ will be re-used for the similarity of $species_j$ to $species_i$. Thus, a nearly 2-fold speed-up is possible, if the similarity function is computationally expensive. (For a discussion of _nonsymmetric_ similarity, see [Leinster and Cobbold](https://doi.org/10.1890/10-2402.1).)
+
+## Parallelization using the ray package
+
+For very large datasets, the computation of the similarity matrix can be completed in a fraction of the time by parallelizing over many cores or even over a Kubernetes cluster.
+Support for parallelizing this computation using the [`ray` package](https://pypi.org/project/ray/) is built into `greylock`. However, this is an optional dependency, 
+as it is not required for small datasets, and 
+the installation of `ray` into your environment may entail some conflicting dependency issues. Thus, before trying to use `ray`, be sure to install the extra:
+
+```
+pip install greylock[ray]
+```
+
+To actually use Ray, replace the use of `SimilarityFromFunction` and `SimilarityFromSymmetricFunction` with `SimilarityFromRayFunction` and `SimilarityFromSymmetricRayFunction` respectively.
+Each `chunk_size` rows of the similarity matrix are processed as a separate job. Thanks to this parallelization, up to an N-fold speedup is possible 
+(where N is the number of cores or nodes).
 
 # Command-line usage
 The `greylock` package can also be used from the command line as a module (via `python -m`). To illustrate using `greylock` this way, we re-use again the example with counts_2b_1 and S_2b, now with counts_2b_1 also saved as a csv file (note again `index=False`):

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ The package is available on GitHub at https://github.com/ArnaoutLab/diversity. I
 
 from the command-line interface. The test suite runs successfully on Macintosh, Windows, and Unix systems. The unit tests (including a coverage report) can be run after installation by
 
-`pytest --pyargs greylock --cov greylock`
+```
+pip install 'greylock[tests]'
+pytest --pyargs greylock --cov greylock
+```
 
 ## How to cite this work
 
@@ -472,7 +475,7 @@ as it is not required for small datasets, and
 the installation of `ray` into your environment may entail some conflicting dependency issues. Thus, before trying to use `ray`, be sure to install the extra:
 
 ```
-pip install greylock[ray]
+pip install 'greylock[ray]'
 ```
 
 To actually use Ray, replace the use of `SimilarityFromFunction` and `SimilarityFromSymmetricFunction` with `SimilarityFromRayFunction` and `SimilarityFromSymmetricRayFunction` respectively.

--- a/README.md
+++ b/README.md
@@ -212,9 +212,9 @@ S_2a[7][8:9] = (                                          0.88) # dodo
 
 S_2a = np.maximum( S_2a, S_2a.transpose() )
 ```
-We may optionally convert this to a DataFrame:
+We may optionally convert this to a DataFrame for inspection:
 ```python
-S_2a = pd.DataFrame({labels_2a[i]: S_2a[i] for i in range(no_species_2a)}, index=labels_2a)
+S_2a_df = pd.DataFrame({labels_2a[i]: S_2a[i] for i in range(no_species_2a)}, index=labels_2a)
 ```
 
 which corresponds to the following table:
@@ -239,11 +239,20 @@ counts_2a = pd.DataFrame({"Community 2a": [1, 1, 1, 1, 1, 1, 1, 1, 1]}, index=la
 ```
 
 To compute the similarity-sensitive diversity indices, we now pass the similarity matrix to the similarity argument of the metacommunity object.
-(Note that `S_2a` may be in the forme of either the numpy array or the DataFrame):
+In this example we pass the similarity matrix in the form of a numpy array:
 
 ```python
 metacommunity_2a = Metacommunity(counts_2a, similarity=S_2a)
 ```
+
+(If we wanted to use the similarity matrix in DataFrame format, we use a custom Similarity subclass.
+
+```python
+from greylock.similarity import SimilarityFromDataFrame
+metacommunity_2a = Metacommunity(counts_2a, similarity=SimilarityFromDataFrame(S_2a_df))
+```
+
+Note that even though the code looks a little different, the calculation will be exactly the same.)
 
 We can find $D_0^Z$ similarly to the above:
 
@@ -271,7 +280,7 @@ S_2b[7][8:9] = (                                          0.85) # llama
 
 S_2b = np.maximum( S_2b, S_2b.transpose() )
 # optional, convert to DataFrame for inspection:
-S_2b = pd.DataFrame({labels_2b[i]: S_2b[i] for i in range(no_species_2b)}, index=labels_2b)
+S_2b_df = pd.DataFrame({labels_2b[i]: S_2b[i] for i in range(no_species_2b)}, index=labels_2b)
 ```
 
 which corresponds to the following table:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     { name = "Elliot Hill", email = "elliot.douglas.hill@gmail.com" },
     { name = "Jasper Braun", email = "jasperbraun90@gmail.com" },
 ]
-version = "0.0.1"
+version = "1.0.0"
 description = "A Python package for measuring the composition of complex datasets"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -17,12 +17,13 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["numpy>=1.24.0", "pandas>=1.5.2", "ray>=2.2.0", "scipy>=1.10.0"]
+dependencies = ["numpy>=1.24.0", "pandas>=1.5.2", "scipy>=1.10.0"]
 
 [project.optional-dependencies]
 tests = ["pytest>=6.2.5", "pytest-cov>=3.0.0"]
 lint = ["black>=22.3.0"]
 ci = ["tox>=3.24.5", "tox-gh-actions>=2.9.1"]
+ray = ["ray>=2.2.0"]
 
 [project.urls]
 "Homepage" = "https://github.com/ArnaoutLab/diversity"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ build-backend = "hatchling.build"
 name = "greylock"
 authors = [
     { name = "Elliot Hill", email = "elliot.douglas.hill@gmail.com" },
+    { name = "Alex Morgan", email = "amorgan2@bidmc.harvard.edu" },
+    { name = "Phuc Nguyen", email = "pnguye10@bidmc.harvard.edu" },
     { name = "Jasper Braun", email = "jasperbraun90@gmail.com" },
 ]
 version = "1.0.0"

--- a/src/greylock/__main__.py
+++ b/src/greylock/__main__.py
@@ -5,6 +5,7 @@ Functions
 main
     Calculates diversities according to command-line specifications.
 """
+
 from sys import argv
 from platform import python_version
 from logging import captureWarnings, getLogger
@@ -14,6 +15,7 @@ from pandas import read_csv
 
 from greylock.log import LOG_HANDLER, LOGGER
 from greylock import Metacommunity
+from greylock.similarity import SimilarityFromFile
 from greylock.parameters import configure_arguments
 
 # Ensure warnings are handled properly.
@@ -37,10 +39,10 @@ def main(args):
 
     counts = read_csv(args.input_filepath, sep=None, engine="python", dtype=int64)
     LOGGER.debug(f"data: {counts}")
+    similarity = SimilarityFromFile(args.similarity, args.chunk_size)
     metacommunity = Metacommunity(
         counts=counts,
-        similarity=args.similarity,
-        chunk_size=args.chunk_size,
+        similarity=similarity,
     )
     community_views = metacommunity.to_dataframe(viewpoint=args.viewpoint)
     community_views.to_csv(

--- a/src/greylock/abundance.py
+++ b/src/greylock/abundance.py
@@ -13,6 +13,7 @@ Functions
 make_abundance
     Chooses and creates instance of concrete Abundance implementation.
 """
+
 from functools import cached_property
 from typing import Iterable, Union
 
@@ -43,7 +44,7 @@ class Abundance:
         self.normalized_subcommunity_abundance = (
             self.make_normalized_subcommunity_abundance()
         )
-        self.unify_abundance_array()
+        self.unified_abundance_array = None
 
     def unify_abundance_array(self):
         """Creates one matrix containing all the abundance matrices:
@@ -53,7 +54,11 @@ class Abundance:
         one copy of the data will exist after garbage collection.)
 
         This allows for a major computational improvement in efficiency:
-        see components.SimilaritySensitiveComponents.
+        The similarity matrix only has to be generated and used
+        once (in the case where a pre-computed similarity matrix is not
+        in RAM). That is, we make only one call to
+        similarity.weighted_abundances(), in cases where generation of the
+        similarity matrix is expensive.
         """
         self.unified_abundance_array = concatenate(
             (
@@ -63,13 +68,46 @@ class Abundance:
             ),
             axis=1,
         )
-        self.metacommunity_abundance = self.unified_abundance_array[:, [0]]
-        self.subcommunity_abundance = self.unified_abundance_array[
-            :, 1 : (1 + self.num_subcommunities)
-        ]
-        self.normalized_subcommunity_abundance = self.unified_abundance_array[
-            :, (1 + self.num_subcommunities) :
-        ]
+
+    def get_unified_abundance_array(self):
+        if self.unified_abundance_array is None:
+            self.unify_abundance_array()
+            self.metacommunity_abundance = self.unified_abundance_array[:, [0]]
+            self.subcommunity_abundance = self.unified_abundance_array[
+                :, 1 : (1 + self.num_subcommunities)
+            ]
+            self.normalized_subcommunity_abundance = self.unified_abundance_array[
+                :, (1 + self.num_subcommunities) :
+            ]
+        return self.unified_abundance_array
+
+    def premultiply_by(self, similarity):
+        if similarity.is_expensive():
+            all_ordinariness = similarity.weighted_abundances(
+                self.get_unified_abundance_array()
+            )
+            metacommunity_ordinariness = all_ordinariness[:, [0]]
+            subcommunity_ordinariness = all_ordinariness[
+                :, 1 : (1 + self.num_subcommunities)
+            ]
+            normalized_subcommunity_ordinariness = all_ordinariness[
+                :, (1 + self.num_subcommunities) :
+            ]
+        else:
+            metacommunity_ordinariness = similarity.weighted_abundances(
+                self.metacommunity_abundance
+            )
+            subcommunity_ordinariness = similarity.weighted_abundances(
+                self.subcommunity_abundance
+            )
+            normalized_subcommunity_ordinariness = similarity.weighted_abundances(
+                self.normalized_subcommunity_abundance
+            )
+        return (
+            metacommunity_ordinariness,
+            subcommunity_ordinariness,
+            normalized_subcommunity_ordinariness,
+        )
 
     def get_subcommunity_names(self, counts: ndarray) -> Iterable:
         """Creates or accesses subcommunity column names then returns
@@ -173,13 +211,6 @@ class AbundanceFromSparseArray(Abundance):
         )
         # Convert to a type that supports slicing:
         self.unified_abundance_array = csc_array(self.unified_abundance_array)
-        self.metacommunity_abundance = self.unified_abundance_array[:, [0]]
-        self.subcommunity_abundance = self.unified_abundance_array[
-            :, 1 : (1 + self.num_subcommunities)
-        ]
-        self.normalized_subcommunity_abundance = self.unified_abundance_array[
-            :, (1 + self.num_subcommunities) :
-        ]
 
     def make_metacommunity_abundance(self) -> ndarray:
         sparse_type = type(self.subcommunity_abundance)

--- a/src/greylock/abundance.py
+++ b/src/greylock/abundance.py
@@ -21,6 +21,7 @@ from numpy import arange, ndarray, concatenate
 from pandas import DataFrame, RangeIndex
 from scipy.sparse import issparse
 
+
 class Abundance:
     """Calculates metacommuntiy and subcommunity relative abundance
     components from a numpy.ndarray containing species counts

--- a/src/greylock/log.py
+++ b/src/greylock/log.py
@@ -7,6 +7,7 @@ LOG_HANDLER: logging.StreamHandler
 LOGGER: logging.Logger
     Multiprocessing-safe logger.
 """
+
 from logging import (
     Formatter,
     StreamHandler,

--- a/src/greylock/parameters.py
+++ b/src/greylock/parameters.py
@@ -10,6 +10,7 @@ Functions
 configure_arguments
     Creates argument parser for .
 """
+
 from argparse import Action, ArgumentParser
 from sys import stdout
 from warnings import warn

--- a/src/greylock/ray.py
+++ b/src/greylock/ray.py
@@ -101,7 +101,7 @@ class SimilarityFromSymmetricRayFunction(SimilarityFromSymmetricFunction):
                     result = result + addend
 
             chunk_future = weighted_similarity_chunk.remote(
-                similarity=self.similarity,
+                similarity=self.func,
                 X=X_ref,
                 relative_abundance=abundance_ref,
                 chunk_size=self.chunk_size,

--- a/src/greylock/ray.py
+++ b/src/greylock/ray.py
@@ -1,0 +1,113 @@
+from typing import Callable, Union
+from numpy import ndarray, empty, concatenate, float64, vstack, zeros
+from pandas import DataFrame
+from scipy.sparse import spmatrix
+import ray
+from greylock.similarity import (
+    SimilarityFromFunction,
+    SimilarityFromSymmetricFunction,
+    weighted_similarity_chunk_nonsymmetric,
+    weighted_similarity_chunk_symmetric,
+)
+
+
+class SimilarityFromRayFunction(SimilarityFromFunction):
+    """Implements Similarity by calculating similarities with a callable
+    function."""
+
+    def __init__(
+        self,
+        func: Callable,
+        X: Union[ndarray, DataFrame],
+        chunk_size: int = 100,
+        max_inflight_tasks: int = 64,
+    ) -> None:
+        """
+        similarity:
+            A Callable that calculates similarity between a pair of
+            species. Must take two rows from X and return a numeric
+            similarity value.
+            If X is a 2D array, the rows will be 1D arrays.
+            If X is a DataFrame, the rows will be named tuples.
+        X:
+            An array or DataFrame where each row contains the feature values
+            for a given species.
+        chunk_size:
+            Determines how many rows of the similarity matrix each will
+            be processes at a time. In general, choosing a larger
+            chunk_size will make the calculation faster, but will also
+            require more memory.
+        """
+        super().__init__(func, X, chunk_size)
+        self.max_inflight_tasks = max_inflight_tasks
+
+    def weighted_abundances(
+        self, relative_abundance: Union[ndarray, spmatrix]
+    ) -> ndarray:
+        weighted_similarity_chunk = ray.remote(weighted_similarity_chunk_nonsymmetric)
+        X_ref = ray.put(self.X)
+        abundance_ref = ray.put(relative_abundance)
+        futures = []
+        results = []
+        for chunk_index in range(0, self.X.shape[0], self.chunk_size):
+            if len(futures) >= self.max_inflight_tasks:
+                ready_refs, futures = ray.wait(futures)
+                results += ray.get(ready_refs)
+            chunk_future = weighted_similarity_chunk.remote(
+                similarity=self.func,
+                X=X_ref,
+                relative_abundance=abundance_ref,
+                chunk_size=self.chunk_size,
+                chunk_index=chunk_index,
+            )
+            futures.append(chunk_future)
+        results += ray.get(futures)
+        results.sort()  # This sorts by chunk index (1st in tuple)
+        weighted_similarity_chunks = [r[1] for r in results]
+        return concatenate(weighted_similarity_chunks)
+
+    def is_expensive(self):
+        return True
+
+
+class SimilarityFromSymmetricRayFunction(SimilarityFromSymmetricFunction):
+    """Implements Similarity by calculating similarities with a callable
+    function for one triangle of the similarity matrix, and re-using those
+    values for the other triangle.
+    """
+
+    def __init__(
+        self,
+        func: Callable,
+        X: Union[ndarray, DataFrame],
+        chunk_size: int = 100,
+        max_inflight_tasks: int = 64,
+    ) -> None:
+        super().__init__(func, X, chunk_size)
+        self.max_inflight_tasks = max_inflight_tasks
+
+    def weighted_abundances(
+        self, relative_abundance: Union[ndarray, spmatrix]
+    ) -> ndarray:
+        weighted_similarity_chunk = ray.remote(weighted_similarity_chunk_symmetric)
+        X_ref = ray.put(self.X)
+        abundance_ref = ray.put(relative_abundance)
+        futures = []
+        result = relative_abundance
+        for chunk_index in range(0, self.X.shape[0], self.chunk_size):
+            if len(futures) >= self.max_inflight_tasks:
+                (ready_refs, futures) = ray.wait(futures)
+                for addend in ray.get(ready_refs):
+                    result = result + addend
+
+            chunk_future = weighted_similarity_chunk.remote(
+                similarity=self.similarity,
+                X=X_ref,
+                relative_abundance=abundance_ref,
+                chunk_size=self.chunk_size,
+                chunk_index=chunk_index,
+            )
+            futures.append(chunk_future)
+        for addend in ray.get(futures):
+            result = result + addend
+        return result

--- a/src/greylock/ray.py
+++ b/src/greylock/ray.py
@@ -66,9 +66,6 @@ class SimilarityFromRayFunction(SimilarityFromFunction):
         weighted_similarity_chunks = [r[1] for r in results]
         return concatenate(weighted_similarity_chunks)
 
-    def is_expensive(self):
-        return True
-
 
 class SimilarityFromSymmetricRayFunction(SimilarityFromSymmetricFunction):
     """Implements Similarity by calculating similarities with a callable

--- a/src/greylock/similarity.py
+++ b/src/greylock/similarity.py
@@ -216,12 +216,12 @@ class SimilarityFromFunction(Similarity):
 
 
 class SimilarityFromSymmetricFunction(SimilarityFromFunction):
-    def weighted_abundance(self, abundance: Union[ndarray, spmatrix]) -> ndarray:
+    def weighted_abundances(self, abundance: Union[ndarray, spmatrix]) -> ndarray:
         result = abundance.copy()
         for chunk_index in range(0, self.X.shape[0], self.chunk_size):
             chunk = weighted_similarity_chunk_symmetric(
                 similarity=self.func,
-                X=X,
+                X=self.X,
                 relative_abundance=abundance,
                 chunk_size=self.chunk_size,
                 chunk_index=chunk_index,

--- a/src/greylock/similarity.py
+++ b/src/greylock/similarity.py
@@ -24,34 +24,20 @@ make_similarity
     Chooses and creates instances of concrete Similarity 
     implementations.
 """
+
 from abc import ABC, abstractmethod
 from typing import Callable, Union
+from pathlib import Path
 from numpy import ndarray, empty, concatenate, float64, vstack, zeros
 from pandas import DataFrame, read_csv
 from scipy.sparse import spmatrix, issparse
-import ray
 
 
 class Similarity(ABC):
     """Interface for classes computing weighted similarities."""
 
-    def __init__(self, similarity: Union[DataFrame, ndarray, str, Callable]) -> None:
-        """
-        Parameters
-        ----------
-        abundance:
-            Contains the relative abundances for the metacommunity and
-            its subcomunities.
-        similarity:
-            A pairwise similarity matrix of shape (n_species, n_species)
-            where each value is the similarity between a pair of
-            species. Species must be in the same order as in the counts
-            argument of the Metacommunity class.
-        """
-        self.similarity = similarity
-
     @abstractmethod
-    def weighted_similarities(
+    def weighted_abundances(
         self, relative_abundances: Union[ndarray, spmatrix]
     ) -> ndarray:
         """Calculates weighted sums of similarities to each species.
@@ -66,12 +52,23 @@ class Similarity(ABC):
         """
         pass
 
+    def is_expensive(self):
+        return False
+
+
+class SimilarityIdentity(Similarity):
+    def weighted_abundances(self, relative_abundance):
+        return relative_abundance
+
 
 class SimilarityFromDataFrame(Similarity):
     """Implements Similarity using similarities stored in pandas
     dataframe."""
 
-    def weighted_similarities(
+    def __init__(self, similarity: DataFrame):
+        self.similarity = similarity
+
+    def weighted_abundances(
         self, relative_abundance: Union[ndarray, spmatrix]
     ) -> ndarray:
         return self.similarity.to_numpy() @ relative_abundance
@@ -81,7 +78,10 @@ class SimilarityFromArray(Similarity):
     """Implements Similarity using similarities stored in a numpy
     ndarray."""
 
-    def weighted_similarities(
+    def __init__(self, similarity: Union[ndarray, spmatrix]):
+        self.similarity = similarity
+
+    def weighted_abundances(
         self, relative_abundance: Union[ndarray, spmatrix]
     ) -> ndarray:
         return self.similarity @ relative_abundance
@@ -95,7 +95,9 @@ class SimilarityFromFile(Similarity):
     memory load.
     """
 
-    def __init__(self, similarity: str, chunk_size: int = 100) -> None:
+    def __init__(
+        self, similarity_file_path: Union[str, Path], chunk_size: int = 100
+    ) -> None:
         """
         Parameters
         ----------
@@ -106,15 +108,15 @@ class SimilarityFromFile(Similarity):
         chunk_size:
             Number of rows to read from similarity matrix at a time.
         """
-        super().__init__(similarity=similarity)
+        self.path = Path(similarity_file_path)
         self.chunk_size = chunk_size
 
-    def weighted_similarities(
+    def weighted_abundances(
         self, relative_abundance: Union[ndarray, spmatrix]
     ) -> ndarray:
-        weighted_similarities = empty(relative_abundance.shape, dtype=float64)
+        weighted_abundances = empty(relative_abundance.shape, dtype=float64)
         with read_csv(
-            self.similarity,
+            self.path,
             chunksize=self.chunk_size,
             sep=None,
             engine="python",
@@ -122,11 +124,14 @@ class SimilarityFromFile(Similarity):
         ) as similarity_matrix_chunks:
             i = 0
             for chunk in similarity_matrix_chunks:
-                weighted_similarities[i : i + self.chunk_size, :] = (
+                weighted_abundances[i : i + self.chunk_size, :] = (
                     chunk.to_numpy() @ relative_abundance
                 )
                 i += self.chunk_size
-        return weighted_similarities
+        return weighted_abundances
+
+    def is_expensive(self):
+        return True
 
 
 def weighted_similarity_chunk_nonsymmetric(
@@ -150,64 +155,6 @@ def weighted_similarity_chunk_nonsymmetric(
     # order. Indicate what chunk this was for, so we can sort the
     # resulting chunks correctly:
     return chunk_index, similarities_chunk @ relative_abundance
-
-
-class SimilarityFromFunction(Similarity):
-    """Implements Similarity by calculating similarities with a callable
-    function."""
-
-    def __init__(
-        self,
-        similarity: Callable,
-        X: Union[ndarray, DataFrame],
-        chunk_size: int = 100,
-        max_inflight_tasks: int = 64,
-    ) -> None:
-        """
-        similarity:
-            A Callable that calculates similarity between a pair of
-            species. Must take two rows from X and return a numeric
-            similarity value.
-            If X is a 2D array, the rows will be 1D arrays.
-            If X is a DataFrame, the rows will be named tuples.
-        X:
-            An array or DataFrame where each row contains the feature values
-            for a given species.
-        chunk_size:
-            Determines how many rows of the similarity matrix each will
-            be processes at a time. In general, choosing a larger
-            chunk_size will make the calculation faster, but will also
-            require more memory.
-        """
-        super().__init__(similarity=similarity)
-        self.X = X
-        self.chunk_size = chunk_size
-        self.max_inflight_tasks = max_inflight_tasks
-
-    def weighted_similarities(
-        self, relative_abundance: Union[ndarray, spmatrix]
-    ) -> ndarray:
-        weighted_similarity_chunk = ray.remote(weighted_similarity_chunk_nonsymmetric)
-        X_ref = ray.put(self.X)
-        abundance_ref = ray.put(relative_abundance)
-        futures = []
-        results = []
-        for chunk_index in range(0, self.X.shape[0], self.chunk_size):
-            if len(futures) >= self.max_inflight_tasks:
-                ready_refs, futures = ray.wait(futures)
-                results += ray.get(ready_refs)
-            chunk_future = weighted_similarity_chunk.remote(
-                similarity=self.similarity,
-                X=X_ref,
-                relative_abundance=abundance_ref,
-                chunk_size=self.chunk_size,
-                chunk_index=chunk_index,
-            )
-            futures.append(chunk_future)
-        results += ray.get(futures)
-        results.sort()  # This sorts by chunk index (1st in tuple)
-        weighted_similarity_chunks = [r[1] for r in results]
-        return concatenate(weighted_similarity_chunks)
 
 
 def weighted_similarity_chunk_symmetric(
@@ -247,95 +194,37 @@ def weighted_similarity_chunk_symmetric(
     return rows_result + cols_result
 
 
-class SimilarityFromSymmetricFunction(SimilarityFromFunction):
-    """Implements Similarity by calculating similarities with a callable
-    function for one triangle of the similarity matrix, and re-using those
-    values for the other triangle.
-    """
+class SimilarityFromFunction(Similarity):
+    def __init__(
+        self, func: Callable, X: Union[ndarray, DataFrame], chunk_size: int = 100
+    ):
+        self.func = func
+        self.X = X
+        self.chunk_size = chunk_size
 
-    def weighted_similarities(
-        self, relative_abundance: Union[ndarray, spmatrix]
-    ) -> ndarray:
-        weighted_similarity_chunk = ray.remote(weighted_similarity_chunk_symmetric)
-        X_ref = ray.put(self.X)
-        abundance_ref = ray.put(relative_abundance)
-        futures = []
-        result = relative_abundance
+    def is_expensive(self):
+        return True
+
+    def weighted_abundances(self, relative_abundance: Union[ndarray, spmatrix]):
+        weighted_similarity_chunks = []
         for chunk_index in range(0, self.X.shape[0], self.chunk_size):
-            if len(futures) >= self.max_inflight_tasks:
-                (ready_refs, futures) = ray.wait(futures)
-                for addend in ray.get(ready_refs):
-                    result = result + addend
+            _, result = weighted_similarity_chunk_nonsymmetric(
+                self.func, self.X, relative_abundance, self.chunk_size, chunk_index
+            )
+            weighted_similarity_chunks.append(result)
+        return concatenate(weighted_similarity_chunks)
 
-            chunk_future = weighted_similarity_chunk.remote(
-                similarity=self.similarity,
-                X=X_ref,
-                relative_abundance=abundance_ref,
+
+class SimilarityFromSymmetricFunction(SimilarityFromFunction):
+    def weighted_abundance(self, abundance: Union[ndarray, spmatrix]) -> ndarray:
+        result = abundance.copy()
+        for chunk_index in range(0, self.X.shape[0], self.chunk_size):
+            chunk = weighted_similarity_chunk_symmetric(
+                similarity=self.func,
+                X=X,
+                relative_abundance=abundance,
                 chunk_size=self.chunk_size,
                 chunk_index=chunk_index,
             )
-            futures.append(chunk_future)
-        for addend in ray.get(futures):
-            result = result + addend
+            result = result + chunk
         return result
-
-
-def make_similarity(
-    similarity: Union[DataFrame, ndarray, str, Callable],
-    X: Union[ndarray, DataFrame] = None,
-    chunk_size: int = 100,
-    symmetric: bool = False,
-    max_inflight_tasks: int = 64,
-) -> Similarity:
-    """Initializes a concrete subclass of Similarity.
-
-    Parameters
-    ----------
-    similarity:
-        If pandas.DataFrame, see
-        diversity.similarity.SimilarityFromDataFrame. If numpy.ndarray,
-        see diversity.similarity.SimilarityFromArray. If str, see
-        diversity.similarity.SimilarityFromFile. If Callable, see
-        diversity.similarity.SimilarityFromFunction
-    X:
-        A 2-d array where each row is a species
-        This can also be a DataFrame whose column names are valid identifiers.
-    chunk_size:
-        See diversity.similarity.SimilarityFromFile. Only relevant
-        if a str is passed as argument for similarity.
-
-    Returns
-    -------
-    An instance of a concrete subclass of Similarity.
-    """
-    if similarity is None:
-        return None
-    elif isinstance(similarity, DataFrame):
-        return SimilarityFromDataFrame(similarity=similarity)
-    elif isinstance(similarity, ndarray):
-        return SimilarityFromArray(similarity=similarity)
-    elif isinstance(similarity, str):
-        return SimilarityFromFile(similarity=similarity, chunk_size=chunk_size)
-    elif isinstance(similarity, Callable):
-        if symmetric:
-            return SimilarityFromSymmetricFunction(
-                similarity=similarity,
-                X=X,
-                chunk_size=chunk_size,
-                max_inflight_tasks=max_inflight_tasks,
-            )
-        else:
-            return SimilarityFromFunction(
-                similarity=similarity,
-                X=X,
-                chunk_size=chunk_size,
-                max_inflight_tasks=max_inflight_tasks,
-            )
-    elif issparse(similarity):
-        return SimilarityFromArray(similarity=similarity)
-    else:
-        raise NotImplementedError(
-            f"Type {type(similarity)} is not supported for argument "
-            "'similarity'. Valid types include pandas.DataFrame, "
-            "numpy.ndarray, numpy.memmap, str, or typing.Callable"
-        )

--- a/src/greylock/tests/abundance_test.py
+++ b/src/greylock/tests/abundance_test.py
@@ -4,12 +4,22 @@ from dataclasses import dataclass, field
 from numpy import allclose, array, ndarray
 from pandas import DataFrame
 from pytest import fixture, mark, raises
+from scipy.sparse import coo_array
 
 from greylock.abundance import (
     Abundance,
     AbundanceFromDataFrame,
     make_abundance,
 )
+
+
+def test_sparse():
+    sparse_abundance = coo_array(
+        (array([4, 5, 7, 9]), (array([0, 3, 1, 0]), array([0, 3, 1, 2]))),
+        shape=(4, 4),
+    )
+    with raises(TypeError):
+        make_abundance(sparse_abundance)
 
 
 def counts_array_3by2():
@@ -244,5 +254,3 @@ class TestAbundance:
             abundance.normalized_subcommunity_abundance,
             test_case.normalized_subcommunity_abundance,
         )
-
-

--- a/src/greylock/tests/abundance_test.py
+++ b/src/greylock/tests/abundance_test.py
@@ -1,4 +1,5 @@
 """Tests for diversity.abundance."""
+
 from dataclasses import dataclass, field
 from numpy import allclose, array, ndarray
 from pandas import DataFrame

--- a/src/greylock/tests/components_test.py
+++ b/src/greylock/tests/components_test.py
@@ -2,40 +2,27 @@ from numpy import allclose
 from pytest import mark
 
 from greylock.metacommunity import Metacommunity
-from greylock.components import (
-    FrequencySensitiveComponents,
-    SimilaritySensitiveComponents,
-)
+from greylock.components import Components
 from greylock.abundance import make_abundance
-from greylock.similarity import make_similarity
-from greylock.components import make_components
 from greylock.tests.metacommunity_test import metacommunity_data
+from greylock.tests.similarity_test import similarity_array_3by3_1
 
 
 @mark.parametrize(
-    "data, expected",
-    zip(
-        metacommunity_data,
-        [
-            FrequencySensitiveComponents,
-            FrequencySensitiveComponents,
-            SimilaritySensitiveComponents,
-            SimilaritySensitiveComponents,
-        ],
-    ),
+    "data",
+    metacommunity_data,
 )
-def test_make_components(data, expected):
-    abundance = make_abundance(counts=data.counts)
-    similarity = make_similarity(similarity=data.similarity)
-    components = make_components(abundance=abundance, similarity=similarity)
-    assert isinstance(components, expected)
+def test_make_components(data):
+    metacommunity = Metacommunity(counts=data.counts, similarity=data.similarity)
+    assert isinstance(metacommunity.components, Components)
 
 
 @mark.parametrize("data", metacommunity_data[2:])
 def test_metacommunity_similarity(data):
     metacommunity = Metacommunity(counts=data.counts, similarity=data.similarity)
     assert allclose(
-        metacommunity.components.metacommunity_similarity, data.metacommunity_similarity
+        metacommunity.components.metacommunity_ordinariness,
+        data.metacommunity_similarity,
     )
 
 
@@ -43,7 +30,7 @@ def test_metacommunity_similarity(data):
 def test_subcommunity_similarity(data):
     metacommunity = Metacommunity(counts=data.counts, similarity=data.similarity)
     assert allclose(
-        metacommunity.components.subcommunity_similarity, data.subcommunity_similarity
+        metacommunity.components.subcommunity_ordinariness, data.subcommunity_similarity
     )
 
 
@@ -51,6 +38,6 @@ def test_subcommunity_similarity(data):
 def test_normalized_subcommunity_similarity(data):
     metacommunity = Metacommunity(counts=data.counts, similarity=data.similarity)
     assert allclose(
-        metacommunity.components.normalized_subcommunity_similarity,
+        metacommunity.components.normalized_subcommunity_ordinariness,
         data.normalized_subcommunity_similarity,
     )

--- a/src/greylock/tests/main_test.py
+++ b/src/greylock/tests/main_test.py
@@ -1,4 +1,5 @@
 """Tests for diversity.__main__."""
+
 from argparse import Namespace
 
 from numpy import inf
@@ -126,13 +127,13 @@ class TestMain:
     @mark.parametrize("test_case", MAIN_TEST_CASES)
     def test_main(self, test_case, tmp_path):
         """Tests __main__.main."""
-        test_case[
-            "args"
-        ].input_filepath = f"{tmp_path}/{test_case['args'].input_filepath}"
+        test_case["args"].input_filepath = (
+            f"{tmp_path}/{test_case['args'].input_filepath}"
+        )
         test_case["args"].similarity = f"{tmp_path}/{test_case['args'].similarity}"
-        test_case[
-            "args"
-        ].output_filepath = f"{tmp_path}/{test_case['args'].output_filepath}"
+        test_case["args"].output_filepath = (
+            f"{tmp_path}/{test_case['args'].output_filepath}"
+        )
 
         self.write_file(
             test_case["args"].input_filepath,

--- a/src/greylock/tests/metacommunity_test.py
+++ b/src/greylock/tests/metacommunity_test.py
@@ -13,9 +13,10 @@ from greylock.exceptions import InvalidArgumentError
 
 from greylock.log import LOGGER
 from greylock.abundance import Abundance
-from greylock.similarity import Similarity
+from greylock.similarity import Similarity, SimilarityIdentity, SimilarityFromArray
 from greylock import Metacommunity
 from greylock.tests.similarity_test import similarity_dataframe_3by3
+from greylock.tests.similarity_test import similarity_array_3by3_1
 
 MEASURES = (
     "alpha",
@@ -226,7 +227,7 @@ class SimilarityMetacommunity3by2:
     description = "similarity-sensitive metacommunity; 3 species, 2 subcommunities"
     viewpoint: float = 2.0
     counts: DataFrame = field(default_factory=lambda: counts_3by2)
-    similarity: DataFrame = field(default_factory=lambda: similarity_dataframe_3by3)
+    similarity: ndarray = field(default_factory=lambda: array(similarity_array_3by3_1))
     metacommunity_similarity: ndarray = field(
         default_factory=lambda: array([[0.76], [0.62], [0.22]])
     )
@@ -297,7 +298,15 @@ metacommunity_data = (
 
 @mark.parametrize(
     "data, expected",
-    zip(metacommunity_data, (type(None), type(None), Similarity, Similarity)),
+    zip(
+        metacommunity_data,
+        (
+            SimilarityIdentity,
+            SimilarityIdentity,
+            SimilarityFromArray,
+            SimilarityFromArray,
+        ),
+    ),
 )
 def test_metacommunity(data, expected):
     metacommunity = Metacommunity(counts=data.counts, similarity=data.similarity)

--- a/src/greylock/tests/parameters_test.py
+++ b/src/greylock/tests/parameters_test.py
@@ -1,4 +1,5 @@
 """Tests for greylock.parameters."""
+
 from pytest import mark, warns
 
 from greylock.parameters import configure_arguments

--- a/src/greylock/tests/ray_test.py
+++ b/src/greylock/tests/ray_test.py
@@ -1,17 +1,31 @@
-from numpy import allclose, ndarray, array, dtype, memmap, inf, float32, zeros
+from numpy import (
+    sum,
+    sqrt,
+    allclose,
+    ndarray,
+    array,
+    dtype,
+    memmap,
+    inf,
+    float32,
+    zeros,
+)
 import ray
-from greylock.ray import SimilarityFromRayFunction
+from greylock.similarity import (
+    SimilarityFromArray,
+    SimilarityFromFunction,
+    SimilarityFromSymmetricFunction,
+)
+from greylock.ray import SimilarityFromRayFunction, SimilarityFromSymmetricRayFunction
 import greylock.tests.mockray as mockray
 from pytest import fixture, raises, mark
 from greylock.tests.similarity_test import (
     relative_abundance_3by2,
     relative_abundance_3by1,
-    weighted_abundances_3by2_3,
-    weighted_abundances_3by2_4,
-    weighted_abundances_3by1_2,
     X_3by1,
     X_3by2,
 )
+from greylock import Metacommunity
 
 
 def ray_fix(monkeypatch):
@@ -26,23 +40,181 @@ def setup(monkeypatch):
     ray_fix(monkeypatch)
 
 
-@fixture
-def similarity_function():
-    return lambda a, b: 1 / sum(a * b)
+MEASURES = (
+    "alpha",
+    "rho",
+    "beta",
+    "gamma",
+    "normalized_alpha",
+    "normalized_rho",
+    "normalized_beta",
+    "rho_hat",
+)
+
+abundances_large = array(
+    [
+        [45, 23],
+        [4, 54],
+        [23, 1],
+        [623, 0],
+        [23, 7],
+        [23, 90],
+        [1, 1],
+        [34, 62],
+        [13, 72],
+        [23, 23],
+        [72, 3],
+        [62, 3],
+        [623, 4],
+        [234, 90],
+        [23, 12],
+        [96, 5],
+        [6, 24],
+        [6, 4],
+        [65, 91],
+        [345, 4],
+        [23, 62],
+        [62, 73],
+        [23, 7],
+        [23, 90],
+        [1, 1],
+        [34, 62],
+        [13, 72],
+        [23, 23],
+        [72, 3],
+        [62, 3],
+        [623, 4],
+        [234, 90],
+        [23, 12],
+        [13, 72],
+        [23, 23],
+        [72, 3],
+        [62, 3],
+        [623, 4],
+        [234, 90],
+        [23, 12],
+        [96, 5],
+        [6, 24],
+        [6, 4],
+        [65, 91],
+        [345, 4],
+        [23, 62],
+        [62, 73],
+        [23, 7],
+        [23, 90],
+        [1, 1],
+        [34, 62],
+        [13, 72],
+        [23, 23],
+        [72, 3],
+        [62, 3],
+        [623, 4],
+        [234, 90],
+        [23, 12],
+        [96, 5],
+        [6, 24],
+        [6, 4],
+        [65, 91],
+        [345, 4],
+        [23, 62],
+        [62, 73],
+        [23, 7],
+    ]
+)
+X_large = array(
+    [
+        [6, 1, 1],
+        [7, 34, 62],
+        [8, 13, 72],
+        [9, 23, 23],
+        [11, 72, 3],
+        [12, 62, 3],
+        [13, 623, 4],
+        [14, 234, 90],
+        [34, 62, 3],
+        [62, 43, 4],
+        [23, 34, 90],
+        [1, 23, 12],
+        [2, 96, 5],
+        [0, 45, 23],
+        [1, 4, 54],
+        [2, 23, 1],
+        [3, 623, 0],
+        [4, 23, 7],
+        [5, 23, 90],
+        [3, 6, 24],
+        [5, 6, 4],
+        [6, 65, 91],
+        [34, 75, 4],
+        [1, 23, 62],
+        [2, 62, 73],
+        [3, 23, 7],
+        [15, 23, 12],
+        [16, 96, 5],
+        [17, 6, 24],
+        [18, 6, 4],
+        [19, 65, 91],
+        [3, 45, 4],
+        [20, 23, 62],
+        [21, 62, 73],
+        [22, 23, 7],
+        [23, 84, 90],
+        [14, 1, 1],
+        [24, 34, 62],
+        [25, 13, 72],
+        [23, 75, 23],
+        [26, 72, 3],
+        [27, 62, 3],
+        [62, 73, 4],
+        [21, 34, 90],
+        [21, 23, 12],
+        [22, 13, 72],
+        [45, 23, 23],
+        [23, 72, 3],
+        [24, 62, 3],
+        [62, 63, 4],
+        [24, 34, 90],
+        [24, 23, 12],
+        [45, 96, 5],
+        [24, 6, 24],
+        [25, 6, 4],
+        [26, 65, 91],
+        [35, 45, 4],
+        [23, 23, 62],
+        [27, 62, 73],
+        [28, 23, 7],
+        [29, 23, 90],
+        [4, 1, 1],
+        [29, 34, 62],
+        [31, 13, 72],
+        [32, 3, 23],
+        [33, 2, 3],
+    ]
+)
+
+
+def similarity_function(a, b):
+    a = a / sqrt(sum(a * a))
+    b = b / sqrt(sum(b * b))
+    return sum(a * b)
 
 
 @mark.parametrize(
-    "relative_abundance, X, chunk_size, expected",
+    "relative_abundance, X, chunk_size",
     [
-        (relative_abundance_3by2, X_3by2, 2, weighted_abundances_3by2_3),
-        (relative_abundance_3by2, X_3by1, 1, weighted_abundances_3by2_4),
-        (relative_abundance_3by1, X_3by2, 4, weighted_abundances_3by1_2),
-        (relative_abundance_3by1, X_3by2, 2, weighted_abundances_3by1_2),
+        (relative_abundance_3by2, X_3by2, 2),
+        (relative_abundance_3by2, X_3by1, 1),
+        (relative_abundance_3by1, X_3by2, 4),
+        (relative_abundance_3by1, X_3by2, 2),
     ],
 )
-def test_weighted_abundances_from_function(
-    relative_abundance, similarity_function, X, chunk_size, expected
-):
+def test_weighted_abundances_from_function(relative_abundance, X, chunk_size):
+    sim_matrix = zeros(shape=(X.shape[0], X.shape[0]))
+    for i in range(X.shape[0]):
+        for j in range(X.shape[0]):
+            sim_matrix[i, j] = similarity_function(X[i], X[j])
+    similarity1 = SimilarityFromArray(sim_matrix)
+    expected = similarity1.weighted_abundances(relative_abundance=relative_abundance)
     similarity = SimilarityFromRayFunction(
         func=similarity_function, X=X, chunk_size=chunk_size
     )
@@ -50,3 +222,26 @@ def test_weighted_abundances_from_function(
         relative_abundance=relative_abundance
     )
     assert allclose(weighted_abundances, expected)
+
+
+def test_comparisons():
+    results = []
+    for i, simclass in enumerate(
+        [
+            SimilarityFromFunction,
+            SimilarityFromRayFunction,
+            SimilarityFromSymmetricFunction,
+            SimilarityFromSymmetricRayFunction,
+        ]
+    ):
+        if i % 2:
+            similarity = simclass(
+                func=similarity_function, X=X_large, chunk_size=4, max_inflight_tasks=2
+            )
+        else:
+            similarity = simclass(func=similarity_function, X=X_large, chunk_size=4)
+        m = Metacommunity(abundances_large, similarity)
+        df = m.to_dataframe(viewpoint=[0, 1, 2, 200], measures=MEASURES)
+        results.append(df.drop(columns="community"))
+    for result in results[1:]:
+        assert allclose(results[0].to_numpy(), result.to_numpy())

--- a/src/greylock/tests/ray_test.py
+++ b/src/greylock/tests/ray_test.py
@@ -1,0 +1,52 @@
+from numpy import allclose, ndarray, array, dtype, memmap, inf, float32, zeros
+import ray
+from greylock.ray import SimilarityFromRayFunction
+import greylock.tests.mockray as mockray
+from pytest import fixture, raises, mark
+from greylock.tests.similarity_test import (
+    relative_abundance_3by2,
+    relative_abundance_3by1,
+    weighted_abundances_3by2_3,
+    weighted_abundances_3by2_4,
+    weighted_abundances_3by1_2,
+    X_3by1,
+    X_3by2,
+)
+
+
+def ray_fix(monkeypatch):
+    monkeypatch.setattr(ray, "put", mockray.put)
+    monkeypatch.setattr(ray, "get", mockray.get)
+    monkeypatch.setattr(ray, "remote", mockray.remote)
+    monkeypatch.setattr(ray, "wait", mockray.wait)
+
+
+@fixture(autouse=True)
+def setup(monkeypatch):
+    ray_fix(monkeypatch)
+
+
+@fixture
+def similarity_function():
+    return lambda a, b: 1 / sum(a * b)
+
+
+@mark.parametrize(
+    "relative_abundance, X, chunk_size, expected",
+    [
+        (relative_abundance_3by2, X_3by2, 2, weighted_abundances_3by2_3),
+        (relative_abundance_3by2, X_3by1, 1, weighted_abundances_3by2_4),
+        (relative_abundance_3by1, X_3by2, 4, weighted_abundances_3by1_2),
+        (relative_abundance_3by1, X_3by2, 2, weighted_abundances_3by1_2),
+    ],
+)
+def test_weighted_abundances_from_function(
+    relative_abundance, similarity_function, X, chunk_size, expected
+):
+    similarity = SimilarityFromRayFunction(
+        func=similarity_function, X=X, chunk_size=chunk_size
+    )
+    weighted_abundances = similarity.weighted_abundances(
+        relative_abundance=relative_abundance
+    )
+    assert allclose(weighted_abundances, expected)

--- a/src/greylock/tests/similarity_test.py
+++ b/src/greylock/tests/similarity_test.py
@@ -1,9 +1,8 @@
 """Tests for diversity.similarity"""
+
 from collections import defaultdict
 from numpy import allclose, ndarray, array, dtype, memmap, inf, float32, zeros
 from pandas import DataFrame
-import ray
-import greylock.tests.mockray as mockray
 import scipy.sparse
 from pytest import fixture, raises, mark
 
@@ -14,23 +13,10 @@ from greylock.similarity import (
     SimilarityFromFile,
     SimilarityFromFunction,
     SimilarityFromSymmetricFunction,
-    make_similarity,
     weighted_similarity_chunk_nonsymmetric,
     weighted_similarity_chunk_symmetric,
 )
 from greylock import Metacommunity
-
-
-def ray_fix(monkeypatch):
-    monkeypatch.setattr(ray, "put", mockray.put)
-    monkeypatch.setattr(ray, "get", mockray.get)
-    monkeypatch.setattr(ray, "remote", mockray.remote)
-    monkeypatch.setattr(ray, "wait", mockray.wait)
-
-
-@fixture(autouse=True)
-def setup(monkeypatch):
-    ray_fix(monkeypatch)
 
 
 @fixture
@@ -111,20 +97,20 @@ relative_abundance_3by2_2 = array(
         [0.2, 0.4],
     ]
 )
-weighted_similarities_3by1_1 = array([[1.051], [2.1005], [10.0201]])
-weighted_similarities_3by1_2 = array([[0.35271989], [0.13459705], [0.0601738]])
-weighted_similarities_3by1_3 = array([[0.35271989], [0.13459705], [0.0601738]])
-weighted_similarities_3by2_1 = array(
+weighted_abundances_3by1_1 = array([[1.051], [2.1005], [10.0201]])
+weighted_abundances_3by1_2 = array([[0.35271989], [0.13459705], [0.0601738]])
+weighted_abundances_3by1_3 = array([[0.35271989], [0.13459705], [0.0601738]])
+weighted_abundances_3by2_1 = array(
     [[1.051, 10.51], [2.1005, 21.005], [10.0201, 100.201]]
 )
-weighted_similarities_3by2_2 = array(
+weighted_abundances_3by2_2 = array(
     [
         [0.81, 0.61],
         [0.77, 0.65],
         [0.29, 0.49],
     ]
 )
-weighted_similarities_3by2_3 = (
+weighted_abundances_3by2_3 = (
     array(
         [
             [0.35271989, 3.52719894],
@@ -133,7 +119,7 @@ weighted_similarities_3by2_3 = (
         ]
     ),
 )
-weighted_similarities_3by2_4 = array(
+weighted_abundances_3by2_4 = array(
     [
         [1.46290476, 14.62904762],
         [0.48763492, 4.87634921],
@@ -158,45 +144,6 @@ def memmapped_similarity_matrix(tmp_path):
     return memmapped
 
 
-@mark.parametrize(
-    "similarity_kwargs, similarity_type",
-    [
-        ({"similarity": similarity_dataframe_3by3}, SimilarityFromDataFrame),
-        ({"similarity": similarity_array_3by3_1}, SimilarityFromArray),
-        (
-            {"similarity": "similarity_matrix.tsv", "chunk_size": 2},
-            SimilarityFromFile,
-        ),
-        (
-            {
-                "similarity": similarity_function,
-                "X": X_3by2,
-                "chunk_size": 2,
-            },
-            SimilarityFromFunction,
-        ),
-    ],
-)
-def test_make_similarity(similarity_kwargs, similarity_type):
-    similarity = make_similarity(**similarity_kwargs)
-    assert isinstance(similarity, similarity_type)
-
-
-def test_do_not_make_similarity():
-    similarity = make_similarity(similarity=None)
-    assert similarity is None
-
-
-def test_make_similarity_from_memmap(memmapped_similarity_matrix):
-    similarity = make_similarity(memmapped_similarity_matrix)
-    assert isinstance(similarity, SimilarityFromArray)
-
-
-def test_make_similarity_not_implemented():
-    with raises(NotImplementedError):
-        make_similarity(similarity=1)
-
-
 @fixture
 def make_similarity_from_file(tmp_path):
     def make(
@@ -207,7 +154,7 @@ def make_similarity_from_file(tmp_path):
         filepath = tmp_path / filename
         with open(filepath, "w") as file:
             file.write(filecontent)
-        return SimilarityFromFile(similarity=filepath, chunk_size=chunk_size)
+        return SimilarityFromFile(similarity_file_path=filepath, chunk_size=chunk_size)
 
     return make
 
@@ -215,86 +162,92 @@ def make_similarity_from_file(tmp_path):
 @mark.parametrize(
     "relative_abundance, expected, kwargs",
     [
-        (relative_abundance_3by2, weighted_similarities_3by2_1, {}),
-        (relative_abundance_3by2, weighted_similarities_3by2_1, {"chunk_size": 2}),
+        (relative_abundance_3by2, weighted_abundances_3by2_1, {}),
+        (relative_abundance_3by2, weighted_abundances_3by2_1, {"chunk_size": 2}),
         (
             relative_abundance_3by2,
-            weighted_similarities_3by2_1,
+            weighted_abundances_3by2_1,
             {
                 "filename": "similarity_matrix.csv",
                 "filecontent": similarities_filecontents_3by3_csv,
             },
         ),
-        (relative_abundance_3by1, weighted_similarities_3by1_1, {}),
+        (relative_abundance_3by1, weighted_abundances_3by1_1, {}),
     ],
 )
-def test_weighted_similarities(
+def test_weighted_abundances(
     relative_abundance, expected, kwargs, make_similarity_from_file
 ):
     similarity = make_similarity_from_file(**kwargs)
-    assert allclose(similarity.weighted_similarities(relative_abundance), expected)
+    assert allclose(similarity.weighted_abundances(relative_abundance), expected)
 
 
 @mark.parametrize(
-    "similarity, relative_abundance, expected",
+    "similarity, simclass, relative_abundance, expected",
     [
         (
             similarity_dataframe_3by3,
+            SimilarityFromDataFrame,
             relative_abundance_3by2,
-            weighted_similarities_3by2_1,
+            weighted_abundances_3by2_1,
         ),
         (
             similarity_dataframe_3by3,
+            SimilarityFromDataFrame,
             relative_abundance_3by1,
-            weighted_similarities_3by1_1,
+            weighted_abundances_3by1_1,
         ),
         (
             similarity_array_3by3_1,
+            SimilarityFromArray,
             relative_abundance_3by1,
-            weighted_similarities_3by1_1,
+            weighted_abundances_3by1_1,
         ),
         (
             similarity_array_3by3_2,
+            SimilarityFromArray,
             relative_abundance_3by2_2,
-            weighted_similarities_3by2_2,
+            weighted_abundances_3by2_2,
         ),
     ],
 )
-def test_weighted_similarities_from_array(similarity, relative_abundance, expected):
-    similarity = make_similarity(similarity=similarity)
-    weighted_similarities = similarity.weighted_similarities(
+def test_weighted_abundances_from_array(
+    similarity, simclass, relative_abundance, expected
+):
+    similarity = simclass(similarity=similarity)
+    weighted_abundances = similarity.weighted_abundances(
         relative_abundance=relative_abundance
     )
-    assert allclose(weighted_similarities, expected)
+    assert allclose(weighted_abundances, expected)
 
 
-def test_weighted_similarities_from_memmap(memmapped_similarity_matrix):
-    similarity = make_similarity(similarity=memmapped_similarity_matrix)
-    weighted_similarities = similarity.weighted_similarities(
+def test_weighted_abundances_from_memmap(memmapped_similarity_matrix):
+    similarity = SimilarityFromArray(similarity=memmapped_similarity_matrix)
+    weighted_abundances = similarity.weighted_abundances(
         relative_abundance=relative_abundance_3by2
     )
-    assert allclose(weighted_similarities, weighted_similarities_3by2_1)
+    assert allclose(weighted_abundances, weighted_abundances_3by2_1)
 
 
 @mark.parametrize(
     "relative_abundance, X, chunk_size, expected",
     [
-        (relative_abundance_3by2, X_3by2, 2, weighted_similarities_3by2_3),
-        (relative_abundance_3by2, X_3by1, 1, weighted_similarities_3by2_4),
-        (relative_abundance_3by1, X_3by2, 4, weighted_similarities_3by1_2),
-        (relative_abundance_3by1, X_3by2, 2, weighted_similarities_3by1_2),
+        (relative_abundance_3by2, X_3by2, 2, weighted_abundances_3by2_3),
+        (relative_abundance_3by2, X_3by1, 1, weighted_abundances_3by2_4),
+        (relative_abundance_3by1, X_3by2, 4, weighted_abundances_3by1_2),
+        (relative_abundance_3by1, X_3by2, 2, weighted_abundances_3by1_2),
     ],
 )
-def test_weighted_similarities_from_function(
+def test_weighted_abundances_from_function(
     relative_abundance, similarity_function, X, chunk_size, expected
 ):
-    similarity = make_similarity(
-        similarity=similarity_function, X=X, chunk_size=chunk_size
+    similarity = SimilarityFromFunction(
+        func=similarity_function, X=X, chunk_size=chunk_size
     )
-    weighted_similarities = similarity.weighted_similarities(
+    weighted_abundances = similarity.weighted_abundances(
         relative_abundance=relative_abundance
     )
-    assert allclose(weighted_similarities, expected)
+    assert allclose(weighted_abundances, expected)
 
 
 def test_weighted_similarity_chunk(similarity_function):
@@ -306,7 +259,7 @@ def test_weighted_similarity_chunk(similarity_function):
         chunk_index=0,
     )
     assert chunk_index == 0
-    assert allclose(chunk, weighted_similarities_3by2_3)
+    assert allclose(chunk, weighted_abundances_3by2_3)
 
 
 def make_array(spec, array_class=zeros):
@@ -329,7 +282,9 @@ def compare_dense_sparse(counts, dense_similarity, sparse_similarity):
     )
     meta_dense = Metacommunity(counts, similarity=dense_similarity)
     meta_dense_df = meta_dense.to_dataframe(viewpoint=viewpoints, measures=measures)
-    meta_sparse = Metacommunity(counts, similarity=sparse_similarity)
+    meta_sparse = Metacommunity(
+        counts, similarity=SimilarityFromArray(sparse_similarity)
+    )
     meta_sparse_df = meta_sparse.to_dataframe(viewpoint=viewpoints, measures=measures)
     assert meta_dense_df.equals(meta_sparse_df)
 
@@ -422,13 +377,11 @@ def test_weighted_similarity_chunk_symmetric(chunk_index, expected):
 def test_symmetric_similarity():
     expected = array([[1.4, 0.8], [1.6, 5.0], [1.4, 8.8], [0.8, 10.4]])
     obj = SimilarityFromSymmetricFunction(
-        similarity=another_similarity_func,
+        func=another_similarity_func,
         X=symmetric_example_X,
         chunk_size=2,
-        max_inflight_tasks=2,
     )
-    assert obj.max_inflight_tasks == 2
-    result = obj.weighted_similarities(symmetric_example_abundance)
+    result = obj.weighted_abundances(symmetric_example_abundance)
     assert allclose(result, expected)
 
 
@@ -614,17 +567,20 @@ def test_feature_similarity():
         "rho_hat",
     ]
     viewpoints = [0, 1, 2, inf]
-    m = Metacommunity(animal_communities, similarity=animal_similarity_matrix())
+    m = Metacommunity(
+        animal_communities,
+        similarity=SimilarityFromDataFrame(animal_similarity_matrix()),
+    )
     df1 = m.to_dataframe(viewpoint=viewpoints, measures=measures).set_index(
         ["community", "viewpoint"]
     )
     m = Metacommunity(
         animal_communities,
-        similarity=feature_similarity,
-        X=animal_features,
-        chunk_size=4,
-        symmetric=False,
-        max_inflight_tasks=2,
+        SimilarityFromFunction(
+            func=feature_similarity,
+            X=animal_features,
+            chunk_size=4,
+        ),
     )
     df2 = m.to_dataframe(viewpoint=viewpoints, measures=measures).set_index(
         ["community", "viewpoint"]
@@ -632,11 +588,11 @@ def test_feature_similarity():
     assert allclose(df1.to_numpy(), df2.to_numpy())
     m = Metacommunity(
         animal_communities,
-        similarity=feature_similarity,
-        X=animal_features,
-        chunk_size=4,
-        symmetric=True,
-        max_inflight_tasks=2,
+        SimilarityFromSymmetricFunction(
+            func=feature_similarity,
+            X=animal_features,
+            chunk_size=4,
+        ),
     )
     df3 = m.to_dataframe(viewpoint=viewpoints, measures=measures).set_index(
         ["community", "viewpoint"]


### PR DESCRIPTION
This is mostly a bunch of refactoring, and a bit of a change to how the API works.

I have done away with the `make_similarity` factory function. This was causing problems for folks who couldn't install ray for whatever reason, and weren't even using the similarity from a function functionality anyway. Having the make_similarity function made MetaCommunity dependent on all the subclasses of Similarity, which were in turn dependent on their dependencies, which included ray. Anyway, it's not Pythonic to switch based on interrogating variables about their type. Python embraces duck typing; let's stop trying to make Python be C++.

This means that in many non-basic cases, the client needs to select and instantiate a subclass of Similarity. I haven't gotten rid of the interrogation of the variable for its type entirely, to not break a couple of really basic cases:
* pass None, and you get an instance of SimilarityIdentity
* pass an ndarray, and you get an instance of SimilarityFromArray
So, existing, really basic uses of this package don't have to migrate.

But now ray is not a mandatory dependency! Just don't try to import from graylock.ray and you don't need ray.

Some documentation had to be updated to reflect this.

Thinking about subclasses of Similarity, I realized I could collapse the subclasses of Components. Rather than having FrequencySensitiveComponents as a separate class, I have the no-Z case use the same code, with the accommodation that premultiplication by SimilarityIdentity is a no-op.

This seemed like an opportunity to work on the test suite some. In the course of this, finding that sparse abundance matrices can cause trouble in some cases, support for sparse abundance matrices has been retracted. Typically there are many more communities than species, though, so sparse similarity matrices are much more important than sparse abundance matrices.