### PR TITLE
conservative version of fix

### DIFF
--- a/src/greylock/abundance.py
+++ b/src/greylock/abundance.py
@@ -17,7 +17,7 @@ make_abundance
 from functools import cached_property
 from typing import Iterable, Union
 
-from numpy import arange, ndarray, concatenate
+from numpy import arange, ndarray, concatenate, minimum
 from pandas import DataFrame, RangeIndex
 from scipy.sparse import issparse  # type: ignore[import]
 
@@ -40,7 +40,7 @@ class Abundance:
         """
         self.subcommunities_names = subcommunity_names
         self.num_subcommunities = counts.shape[1]
-        self.min_count = 1/counts.sum()
+        self.min_count = minimum(1/counts.sum(), 1e-9)
 
         self.subcommunity_abundance = self.make_subcommunity_abundance(counts=counts)
         self.metacommunity_abundance = self.make_metacommunity_abundance()

--- a/src/greylock/abundance.py
+++ b/src/greylock/abundance.py
@@ -40,6 +40,7 @@ class Abundance:
         """
         self.subcommunities_names = subcommunity_names
         self.num_subcommunities = counts.shape[1]
+        self.min_count = 1/counts.sum()
 
         self.subcommunity_abundance = self.make_subcommunity_abundance(counts=counts)
         self.metacommunity_abundance = self.make_metacommunity_abundance()

--- a/src/greylock/metacommunity.py
+++ b/src/greylock/metacommunity.py
@@ -116,6 +116,7 @@ class Metacommunity:
             order=1 - viewpoint,
             weights=self.abundance.normalized_subcommunity_abundance,
             items=community_ratio,
+            atol=self.abundance.min_count
         )
         if measure in {"beta", "normalized_beta"}:
             return 1 / diversity_measure


### PR DESCRIPTION
I don't know why we have a tolerance set for weights in `power_mean` rather than just test `weights != 0.0`.  In ever use case I've ever seen, abundances are integer numbers. Close to zero counts include 0 (which is zero) and 1 (which is not 1). 
Won't `0/counts.sum()` always be 0.0??? (Even though we go into floating point territory, and things get inexact... Zero is exactly representable as a float.) 

But, anyway, for fear of throwing out some baby with the bathwater, I've retained the idea of having a tolerance for considering weights close to zero in `power_mean`. I've just adjusted it so that any species of count 1 is non-zero. 

Things could get funky if the tolerance approaches np.finfo(np.float64).tiny but given that that would require total counts on the order of $10^{307}$, that seems far-fetched. 