### PR TITLE
fix test to use allclose

### DIFF
--- a/src/greylock/tests/similarity_test.py
+++ b/src/greylock/tests/similarity_test.py
@@ -394,7 +394,9 @@ def compare_dense_sparse(counts, dense_similarity, sparse_similarity):
         counts, similarity=SimilarityFromArray(sparse_similarity)
     )
     meta_sparse_df = meta_sparse.to_dataframe(viewpoint=viewpoints, measures=measures)
-    assert meta_dense_df.equals(meta_sparse_df)
+    for col in meta_dense_df:
+        if col != "community":
+            assert allclose(meta_dense_df[col], meta_sparse_df[col])
 
 
 @mark.parametrize(


### PR DESCRIPTION
Yup, it was a numerically insignificant difference, and DataFrame.equals is too brittle.