### PR TITLE
Rename 'diversity' package to 'sentropy'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Note**
 >
-> The **`diversity`** package has been **renamed to `sentropy`**.
+> The **`greylock`** package has been **renamed to `sentropy`**.
 >
 > 🚫 **This repository is no longer maintained.**
 >


### PR DESCRIPTION
Updated README to reflect package renaming from 'diversity' to 'sentropy'.